### PR TITLE
Add overview screen in codelists tab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,8 +136,16 @@
 
         <!-- Codelists -->
         <div class="tab-pane fade" id="codelists" role="tabpanel" aria-labelledby="codelists-tab">
-            <p>TODO: Add UI comparing codelists.json and displaying only added/removed codelists or codelists with
-                different version numbers.</p>
+                  <!-- Code-lists overview -->
+                  <div id="code-lists-overview" class="container-fluid h-100 mb-3">
+                    <nav aria-label="breadcrumb">
+                        <ol class="breadcrumb">
+                            <li class="breadcrumb-item" aria-current="page">Overview</li>
+                        </ol>
+                    </nav>
+                    <div id="code-lists-overview-card-group" class="card-group"></div>
+                </div>
+
         </div>
 
         <!-- Schemas -->
@@ -207,10 +215,9 @@
     <div class="card">
         <div class="card-body" id="card-header" style="display: flex; flex-direction: row; align-items: flex-start;">
             <div style="flex: 1;">
-                <h1 id="title" class="card-title"></h1>
+                <h2 id="title" class="card-title"></h2>
                 <h5 id="subtitle" class="card-subtitle"></h5>
             </div>
-            <button id="action-button" type="button" class="btn btn-outline-primary"></button>
         </div>
         <ul id="property-list" class="list-group list-group-flush">
         </ul>

--- a/index.html
+++ b/index.html
@@ -211,6 +211,11 @@
             background-color: var(--modified-item-background-color);
             color: black;
         }
+        h2 {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     </style>
     <div class="card">
         <div class="card-body" id="card-header" style="display: flex; flex-direction: row; align-items: flex-start;">

--- a/index.html
+++ b/index.html
@@ -211,14 +211,46 @@
             background-color: var(--modified-item-background-color);
             color: black;
         }
+
+        .unchanged-card {
+            background-color: var(--unchanged-item-background-color);
+            color: black;
+        }
+
+        .card {
+            box-shadow: 1px 1px 3px 1px lightgray;
+        }
+
+        .card-header {
+            animation: fadeToWhite 1s infinite;
+            border-bottom-width: 5px;
+        }
+
+        .card-header.added-card,
+        .card-header.removed-card,
+        .card-header.modified-card,
+        .card-header.unchanged-card {
+            animation: none;
+        }
+
+        @keyframes fadeToWhite {
+            0%,
+            100% {
+                background-color: var(--light-background-color);
+            }
+
+            50% {
+                background-color: white;
+            }
+        }
+
         h2 {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }
-    </style>
-    <div class="card">
-        <div class="card-body" id="card-header" style="display: flex; flex-direction: row; align-items: flex-start;">
+    </style>   <div class="card">
+        <div class="card-header" id="card-header" style="display: flex; flex-direction: row; align-items: flex-start;">
             <div style="flex: 1;">
                 <h2 id="title" class="card-title"></h2>
                 <h5 id="subtitle" class="card-subtitle"></h5>

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -6,6 +6,7 @@
     --added-item-background-color: #E6FFEC;
     --removed-item-background-color: #FFEBE9;
     --modified-item-background-color: #E6E9FF;
+    --unchanged-item-background-color: #f8f9fa;
     --op-green-color: #2c862d;
     --dark-background-color: #EEEEEE;
     --light-background-color: #f8f9fa;

--- a/src/js/codelists-tab.js
+++ b/src/js/codelists-tab.js
@@ -1,4 +1,10 @@
+import { appState } from "./state.js";
+import { appConfig } from "./config.js";
+import { Diff, DiffEntry } from "./diff.js";
 import { TabController } from "./tab-controller.js";
+import { PropertyCard } from "./property-card.js";
+import { IndexCard } from "./index-card.js";
+import { SdkExplorerApplication } from "./app.js";
 
 export class CodelistsTab extends TabController {
 
@@ -7,6 +13,155 @@ export class CodelistsTab extends TabController {
     }
 
     async fetchAndRender() {
-        // TODO: implement
+        this.fetchAndRenderOverview();
+    }
+
+
+    /**
+     * Fetches thecodelists.json index files for both versions and renders the overview display.
+     */
+    async fetchAndRenderOverview() {    
+        SdkExplorerApplication.startSpinner();
+        try {
+
+            // Get code-lists.json index files for both versions.
+            const [mainVersionData, baseVersionData] = await Promise.all([
+                this.#fetchCodeListsIndexFile(appState.mainVersion),
+                this.#fetchCodeListsIndexFile(appState.baseVersion)
+            ]);
+
+            // Compare the two index files
+            const diff = Diff.fromArrayComparison(mainVersionData.codelists, baseVersionData.codelists, 'id');
+
+            // Clear existing index-cards.
+            $('#code-lists-overview-card-group').empty();
+
+            // Create and add an index-card for each code list.
+            diff.forEach(entry => {
+                const card = this.#createIndexCard(entry);
+                $('#code-lists-overview-card-group').append(card);
+            });
+
+             this.#switchToOverview();
+        } catch (error) {
+            console.error('Error while generating overview:', error);
+            throw new Error('Failed to load code list');
+        } finally {
+            SdkExplorerApplication.stopSpinner();
+        }
+    }
+
+        /**
+     * Fetches the code-lists.json index file for the specified SDK version.
+     */
+        async #fetchCodeListsIndexFile(sdkVersion) {
+            const url = this.#getCodeListsIndexFileUrl(sdkVersion);
+            try {
+                const response = await $.ajax({ url, dataType: 'json' });
+                return response;
+            } catch (error) {
+                console.error('Error fetching code-lists.json:', error);
+                throw error;
+            }
+        }
+
+        
+    #getCodeListsIndexFileUrl(sdkVersion) {
+        return `${appConfig.rawBaseUrl}/${sdkVersion}/codelists/codelists.json`;
+    }
+
+    
+    #switchToOverview() {
+        //$('#code-lists-explorer-view').hide();
+        $('#code-lists-overview').show();
+    }
+
+     /**
+     * Creates an index-card for the specified code list.
+     * 
+     * @param {DiffEntry} diffEntry 
+     * @returns 
+     */
+     #createIndexCard(diffEntry) {
+        const component = IndexCard.create(diffEntry.get('id'), diffEntry.get('_label'), 'Compare', diffEntry.typeOfChange);
+        // Not needed for now
+        // component.setActionHandler((e) => {
+        //     e.preventDefault();
+        //     this.fetchAndRenderExplorerView(diffEntry.get('id'));
+        // });
+        // If the code list is not new or removed, then we will need to check for changes inside the code list file.
+        if (diffEntry.typeOfChange !== Diff.TypeOfChange.ADDED && diffEntry.typeOfChange !== Diff.TypeOfChange.REMOVED) {
+            component.removeAttribute('status');
+            component.setStatusCheckCallback(() => Promise.resolve(this.#checkForChanges(diffEntry.baseItem.filename)));
+        }
+
+        for (const [key, value] of Object.entries(diffEntry.getItem())) {
+            const mainValue = diffEntry?.mainItem ? diffEntry?.mainItem[key] ?? undefined : undefined;
+            const baseValue = diffEntry?.baseItem ? diffEntry?.baseItem[key] ?? undefined : undefined;
+
+            const card = PropertyCard.create(key, mainValue, baseValue, diffEntry.typeOfChange);
+            component.appendProperty(card);
+        }
+
+        // Handle removed properties (the ones in baseItem that do not exit in mainItem).
+        if (diffEntry.mainItem) {
+            for (const propertyName in diffEntry.baseItem) {
+                if (!diffEntry.mainItem.hasOwnProperty(propertyName)) {
+                    const card = PropertyCard.create(propertyName, undefined, diffEntry.baseItem[propertyName]);
+                    component.appendProperty(card);
+                }
+            }
+        }
+
+        return component;
+    }
+
+     /**
+     * Checks for changes in the code list  file.
+     * It will ignore the values of certain properties that are expected to change between versions: 
+     * (ublVersion, sdkVersion, metadataDatabase.version and metadataDatabase.createdOn).
+     * 
+     * @param {string} filename The codelist file to check for changes
+     * @returns {Promise<Diff.TypeOfChange>} The type of change detected
+     */
+     async #checkForChanges(filename) {
+        try {
+            SdkExplorerApplication.startSpinner();
+            let mainUrl = this.#getUrlCodeListsAndVersion(filename, appState.mainVersion);
+            let baseUrl = this.#getUrlCodeListsAndVersion(filename, appState.baseVersion);
+            let mainFile = await $.ajax({ url: mainUrl, dataType: 'text' });
+            let baseFile = await $.ajax({ url: baseUrl, dataType: 'text' });
+
+            let versionRegex = /<Version>(.*?)<\/Version>/;
+            
+            // Extract version information from the XML content
+            let mainVersionMatch = mainFile.match(versionRegex);
+            let baseVersionMatch = baseFile.match(versionRegex);
+    
+            // If version tag is not found, return null to indicate an error or unknown state
+            if (!mainVersionMatch || !baseVersionMatch) {
+                console.error(`Version tag not found in one of the files for ${filename}.json`);
+                return null;
+            }
+    
+            let mainVersion = mainVersionMatch[1];
+            let baseVersion = baseVersionMatch[1];
+    
+            let nodeChange = mainVersion === baseVersion ? Diff.TypeOfChange.UNCHANGED : Diff.TypeOfChange.MODIFIED;
+            
+            return nodeChange;
+        } catch (error) {
+            
+            console.error(`Error processing files for ${filename}.json:`, error);
+            return null;
+        }
+        finally {
+            SdkExplorerApplication.stopSpinner();
+        }   
+    }
+    
+
+    #getUrlCodeListsAndVersion(filename, sdkVersion) {
+        return `${appConfig.rawBaseUrl}/${sdkVersion}/codelists/${filename}`;
     }
 }

--- a/src/js/codelists-tab.js
+++ b/src/js/codelists-tab.js
@@ -83,7 +83,7 @@ export class CodelistsTab extends TabController {
      * @returns 
      */
      #createIndexCard(diffEntry) {
-        const component = IndexCard.create(diffEntry.get('id'), diffEntry.get('_label'), 'Compare', diffEntry.typeOfChange);
+        const component = IndexCard.create(diffEntry.get('id'), diffEntry.get('parentId') ?? '', 'Compare', diffEntry.typeOfChange);
         // Not needed for now
         // component.setActionHandler((e) => {
         //     e.preventDefault();

--- a/src/js/codelists-tab.js
+++ b/src/js/codelists-tab.js
@@ -37,11 +37,12 @@ export class CodelistsTab extends TabController {
             $('#code-lists-overview-card-group').empty();
 
             // Create and add an index-card for each code list.
-            diff.forEach(entry => {
-                const card = this.#createIndexCard(entry);
-                $('#code-lists-overview-card-group').append(card);
+            diff.forEach((entry, index) => {
+                setTimeout(() => {
+                    const card = this.#createIndexCard(entry);
+                    $('#code-lists-overview-card-group').append(card);
+                }, 0);
             });
-
              this.#switchToOverview();
         } catch (error) {
             console.error('Error while generating overview:', error);

--- a/src/js/index-card.js
+++ b/src/js/index-card.js
@@ -76,9 +76,9 @@ export class IndexCard extends BootstrapWebComponent {
         if (this.actionName && this.actionHandler) {
             button.textContent = this.actionName;
             button.onclick = this.actionHandler;
-            button.style.display = ''; // Show the button
+            button.style.display = ''; 
         } else {
-            button.style.display = 'none'; // Hide the button
+            button.style.display = 'none';
         }
     }
     

--- a/src/js/index-card.js
+++ b/src/js/index-card.js
@@ -42,7 +42,7 @@ export class IndexCard extends BootstrapWebComponent {
         switch (name) {
             case 'title': this.title = newValue; break;
             case 'subtitle': this.subTitle = newValue; break;
-            case 'action-name': this.actionName = newValue;  break;
+            case 'action-name': this.actionName = newValue; break;
             case 'status': this.status = newValue; break;
         }
 
@@ -90,7 +90,7 @@ export class IndexCard extends BootstrapWebComponent {
     setStatusCheckCallback(statusCheckCallback) {
         this.getStatusCallback = statusCheckCallback;
     }
- 
+
     appendProperty(propertyCard) {
         this.propertyCards.push(propertyCard);
         if (this.isConnected) {

--- a/src/js/index-card.js
+++ b/src/js/index-card.js
@@ -54,18 +54,34 @@ export class IndexCard extends BootstrapWebComponent {
 
     render() {
         super.render();
-
+    
         const propertyList = this.shadowRoot.querySelector('#property-list');
         this.propertyCards.forEach(propertyCard => propertyList.append(propertyCard));
-
+    
         this.shadowRoot.querySelector('#title').textContent = this.title;
         this.shadowRoot.querySelector('#subtitle').textContent = this.subTitle;
         this.shadowRoot.querySelector('#card-header').classList.add(this.status + '-card');
-
-        const button = this.shadowRoot.querySelector('#action-button');
-        button.textContent = this.actionName;
-        button.onclick = this.actionHandler;
+    
+        // Retrieve or create the button element
+        let button = this.shadowRoot.querySelector('#action-button');
+        if (!button) {
+            button = document.createElement('button');
+            button.setAttribute('id', 'action-button');
+            button.setAttribute('type', 'button');
+            button.classList.add('btn', 'btn-outline-primary');
+            this.shadowRoot.querySelector('#card-header').appendChild(button);
+        }
+    
+        // Conditionally configure and display the button
+        if (this.actionName && this.actionHandler) {
+            button.textContent = this.actionName;
+            button.onclick = this.actionHandler;
+            button.style.display = ''; // Show the button
+        } else {
+            button.style.display = 'none'; // Hide the button
+        }
     }
+    
 
     /**
      * Called each time the element is added to the document.

--- a/src/js/notice-types-tab.js
+++ b/src/js/notice-types-tab.js
@@ -53,8 +53,10 @@ export class NoticeTypesTab extends TabController {
 
             // Create and add an index-card for each notice type.
             diff.forEach(entry => {
-                const card = this.#createIndexCard(entry);
-                $('#notice-types-overview-card-group').append(card);
+                setTimeout(() => {
+                    const card = this.#createIndexCard(entry);
+                    $('#notice-types-overview-card-group').append(card);
+                }, 0);
             });
 
             this.#switchToOverview();


### PR DESCRIPTION
Codelists tab needs an overview screen like the one we have for notice-types.
There will be no "Compare" button though as the SDK Explorer will not drill-down to show individual code changes.
The overview will contain index-cards, with their header highlighted according to their modification status just like it is done for notice-types.

The modification status will be checked in the background, like in notice-types, by opening the individual files and comparing them.
When comparing the files. make sure to exclude the <!-- comment ---> timestamping their creation before comparison.