### PR TITLE
Fix for Schemas comparison not working after

### DIFF
--- a/src/js/tabs/schemas-tab.js
+++ b/src/js/tabs/schemas-tab.js
@@ -104,8 +104,8 @@ export class SchemasTab extends TabController {
       async #fetchIndexFile(sdkVersion) {
         try {
             const url = this.#getIndexFileUrl(sdkVersion);
-            const response = await this.ajaxRequest({ url: url, dataType: 'json' });
-            return response;
+            const { schemas } = await this.ajaxRequest({ url, dataType: 'json' });
+            return schemas;
         } catch (error) {
             if (error.status === 404) {
                 console.warn(`schemas.json not found for SDK ${sdkVersion}, fetching filenames from schema folder.`);


### PR DESCRIPTION
 Diff.fromArrayComparison(mainVersionData, baseVersionData, 'filename');
 was comparing an object with an array. We updated the code to return the array on the fetch of index file
